### PR TITLE
Add Viren live automation hub workflow and docs

### DIFF
--- a/n8n/live-automation-hub/README.md
+++ b/n8n/live-automation-hub/README.md
@@ -1,0 +1,29 @@
+# Viren Live Automation Hub Workflow
+
+This folder contains the **main_workflow.json** blueprint for the Viren Live Automation Hub. The workflow lets Viren receive commands through HTTP or Telegram, convert natural language instructions into GitHub updates using OpenAI, and send confirmations or error alerts.
+
+## Importing the Workflow
+1. Download `main_workflow.json`.
+2. In your n8n dashboard, select **Import Workflow** and upload the JSON file.
+3. Set the following environment variables in n8n:
+   - `OPENAI_API_KEY`
+   - `GITHUB_TOKEN` (if the repository is private)
+   - `GITHUB_OWNER`
+   - `GITHUB_REPO`
+   - `TELEGRAM_BOT_TOKEN`
+4. Activate the workflow.
+
+## Using the Hub
+- Send a POST request to the `/viren-webhook` endpoint **or** message the Telegram bot.
+- The text is routed to OpenAI, transformed into repo-ready tasks, committed to GitHub, and a confirmation is returned.
+- Errors are captured and forwarded to your Telegram chat ID specified in the workflow.
+
+## Example Golden Test
+1. Send: `Generate a poem about Paradize and add to repo` via Telegram or HTTP POST.
+2. Expected result: A new file is committed to the repository and a confirmation message is returned.
+
+## Observability & Error Handling
+- Uses the n8n **Error Trigger** node to send alerts on workflow failures.
+- Successful operations respond via HTTP or Telegram for auditability.
+
+Extend or customize triggers and outputs as your automation hub evolves.

--- a/n8n/live-automation-hub/main_workflow.json
+++ b/n8n/live-automation-hub/main_workflow.json
@@ -1,0 +1,210 @@
+{
+  "name": "Viren Live Automation Hub",
+  "nodes": [
+    {
+      "parameters": {
+        "path": "viren-webhook",
+        "methods": ["POST"]
+      },
+      "id": "http-trigger",
+      "name": "HTTP Command",
+      "type": "n8n-nodes-base.webhook",
+      "typeVersion": 1,
+      "position": [250, 200]
+    },
+    {
+      "parameters": {
+        "updates": ["message"]
+      },
+      "id": "telegram-trigger",
+      "name": "Telegram Command",
+      "type": "n8n-nodes-base.telegramTrigger",
+      "typeVersion": 1,
+      "position": [250, 400],
+      "credentials": {
+        "telegramApi": {
+          "id": "telegram-credentials",
+          "name": "Telegram API"
+        }
+      }
+    },
+    {
+      "parameters": {
+        "mode": "mergeByIndex"
+      },
+      "id": "merge",
+      "name": "Merge Commands",
+      "type": "n8n-nodes-base.merge",
+      "typeVersion": 1,
+      "position": [500, 300]
+    },
+    {
+      "parameters": {
+        "operation": "chat",
+        "model": "gpt-4o-mini",
+        "prompt": "Convert input: {{$json[\"message\"] || $json[\"body\"]}} into actionable repo task with file content if needed."
+      },
+      "id": "openai",
+      "name": "Viren AI",
+      "type": "n8n-nodes-base.openAi",
+      "typeVersion": 1,
+      "position": [700, 300],
+      "credentials": {
+        "openAiApi": {
+          "id": "openai-credentials",
+          "name": "OpenAI API"
+        }
+      }
+    },
+    {
+      "parameters": {
+        "operation": "create",
+        "owner": "{{$env.GITHUB_OWNER}}",
+        "repository": "{{$env.GITHUB_REPO}}",
+        "filePath": "tasks/{{$json.fileName}}",
+        "fileContent": "{{$json.fileContent}}",
+        "commitMessage": "Viren task: {{$json.commitMessage}}"
+      },
+      "id": "github",
+      "name": "GitHub Commit",
+      "type": "n8n-nodes-base.github",
+      "typeVersion": 2,
+      "position": [900, 300],
+      "credentials": {
+        "githubApi": {
+          "id": "github-credentials",
+          "name": "GitHub API"
+        }
+      }
+    },
+    {
+      "parameters": {
+        "chatId": "{{$json.chatId}}",
+        "text": "✅ Task processed and pushed: {{$json.commitMessage}}"
+      },
+      "id": "telegram-send",
+      "name": "Telegram Confirm",
+      "type": "n8n-nodes-base.telegram",
+      "typeVersion": 1,
+      "position": [1100, 400],
+      "credentials": {
+        "telegramApi": {
+          "id": "telegram-credentials",
+          "name": "Telegram API"
+        }
+      }
+    },
+    {
+      "parameters": {
+        "responseMode": "onReceived",
+        "responseData": "Task processed and pushed."
+      },
+      "id": "http-response",
+      "name": "HTTP Response",
+      "type": "n8n-nodes-base.respondToWebhook",
+      "typeVersion": 1,
+      "position": [1100, 200]
+    },
+    {
+      "parameters": {},
+      "id": "error-trigger",
+      "name": "Error Trigger",
+      "type": "n8n-nodes-base.errorTrigger",
+      "typeVersion": 1,
+      "position": [250, 600]
+    },
+    {
+      "parameters": {
+        "chatId": "<YOUR_CHAT_ID>",
+        "text": "❌ Error: {{$json.error.message}}"
+      },
+      "id": "telegram-error",
+      "name": "Telegram Error",
+      "type": "n8n-nodes-base.telegram",
+      "typeVersion": 1,
+      "position": [500, 600],
+      "credentials": {
+        "telegramApi": {
+          "id": "telegram-credentials",
+          "name": "Telegram API"
+        }
+      }
+    }
+  ],
+  "connections": {
+    "HTTP Command": {
+      "main": [
+        [
+          {
+            "node": "Merge Commands",
+            "type": "main",
+            "index": 0
+          }
+        ]
+      ]
+    },
+    "Telegram Command": {
+      "main": [
+        [
+          {
+            "node": "Merge Commands",
+            "type": "main",
+            "index": 1
+          }
+        ]
+      ]
+    },
+    "Merge Commands": {
+      "main": [
+        [
+          {
+            "node": "Viren AI",
+            "type": "main",
+            "index": 0
+          }
+        ]
+      ]
+    },
+    "Viren AI": {
+      "main": [
+        [
+          {
+            "node": "GitHub Commit",
+            "type": "main",
+            "index": 0
+          }
+        ]
+      ]
+    },
+    "GitHub Commit": {
+      "main": [
+        [
+          {
+            "node": "Telegram Confirm",
+            "type": "main",
+            "index": 0
+          },
+          {
+            "node": "HTTP Response",
+            "type": "main",
+            "index": 0
+          }
+        ]
+      ]
+    },
+    "Error Trigger": {
+      "main": [
+        [
+          {
+            "node": "Telegram Error",
+            "type": "main",
+            "index": 0
+          }
+        ]
+      ]
+    }
+  },
+  "settings": {
+    "executionOrder": "v1"
+  }
+}


### PR DESCRIPTION
## Summary
- Add main_workflow.json for Viren Live Automation Hub, routing HTTP/Telegram commands through OpenAI and GitHub
- Provide README for importing workflow, environment variables, and golden test

## Testing
- `python -m pytest`
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_689da9c1039c83239fa0816b0b3feb90